### PR TITLE
Add __stepname__ attribute to plugin __init__.

### DIFF
--- a/mapclientplugins/textwriterstep/__init__.py
+++ b/mapclientplugins/textwriterstep/__init__.py
@@ -4,6 +4,7 @@ MAP Client Plugin
 '''
 __version__ = '0.1.0'
 __author__ = 'Li Jiun Chen'
+__stepname__ = 'TextWriter'
 
 # import class that derives itself from the step mountpoint.
 from mapclientplugins.textwriterstep import step


### PR DESCRIPTION
This attribute is used by the MAP-Client to keep track of all the currently installed plugins, without it a number of MAP-Client plugin manager methods do not function correctly.